### PR TITLE
update URLs from stealthrocket to dispatchrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-<img src="https://github.com/stealthrocket/dispatch-proto/assets/865510/87162355-e184-4058-a733-650eee53f333" width="160"/>
+<img src="https://github.com/dispatchrun/dispatch-proto/assets/865510/87162355-e184-4058-a733-650eee53f333" width="160"/>
 </p>
 
 # dispatch-py
 
-[![Docs](https://github.com/stealthrocket/dispatch-py/actions/workflows/docs.yml/badge.svg?branch=)](https://github.com/stealthrocket/dispatch-py/actions/workflows/docs.yml)
-[![PyPI](https://github.com/stealthrocket/dispatch-py/actions/workflows/pypi.yml/badge.svg?branch=)](https://github.com/stealthrocket/dispatch-py/actions/workflows/pypi.yml)
-[![Test](https://github.com/stealthrocket/dispatch-py/actions/workflows/test.yml/badge.svg?branch=)](https://github.com/stealthrocket/dispatch-py/actions/workflows/test.yml)
+[![Docs](https://github.com/dispatchrun/dispatch-py/actions/workflows/docs.yml/badge.svg?branch=)](https://github.com/dispatchrun/dispatch-py/actions/workflows/docs.yml)
+[![PyPI](https://github.com/dispatchrun/dispatch-py/actions/workflows/pypi.yml/badge.svg?branch=)](https://github.com/dispatchrun/dispatch-py/actions/workflows/pypi.yml)
+[![Test](https://github.com/dispatchrun/dispatch-py/actions/workflows/test.yml/badge.svg?branch=)](https://github.com/dispatchrun/dispatch-py/actions/workflows/test.yml)
 [![PyPI version](https://badge.fury.io/py/dispatch-py.svg)](https://badge.fury.io/py/dispatch-py)
 [![Reference](https://img.shields.io/badge/API-Reference-lightblue.svg)](https://python.dispatch.run/main/reference/dispatch/)
 
@@ -45,12 +45,12 @@ configuration and execution of applications that use Dispatch. On macOS, this
 can be done easily using [Homebrew](https://docs.brew.sh/):
 
 ```console
-brew tap stealthrocket/dispatch
+brew tap dispatchrun/dispatch
 brew install dispatch
 ```
 
 Alternatively, you can download the latest `dispatch` binary from the
-[Releases](https://github.com/stealthrocket/dispatch/releases) page.
+[Releases](https://github.com/dispatchrun/dispatch/releases) page.
 
 *Note that this step is optional, applications that use Dispatch can run without
 the CLI, passing configuration through environment variables or directly in the
@@ -156,7 +156,7 @@ async def transform(msg):
 Dispatch converts Python coroutines to *Distributed Coroutines*, which can be
 suspended and resumed on any instance of a service across a fleet. For a deep
 dive on these concepts, read our blog post on
-[*Distributed Coroutines with a Native Python Extension and Dispatch*](https://stealthrocket.tech/blog/distributed-coroutines-in-python).
+[*Distributed Coroutines with a Native Python Extension and Dispatch*](https://dispatch.run/blog/distributed-coroutines-in-python).
 
 ### Integration with FastAPI
 
@@ -231,7 +231,7 @@ the pickle library attempts serialization.
 
 For help with a serialization issues, please submit a [GitHub issue][issues].
 
-[issues]: https://github.com/stealthrocket/dispatch-py/issues
+[issues]: https://github.com/dispatchrun/dispatch-py/issues
 
 ## Examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 This is the API reference for the Python SDK of Dispatch.
 
 - Tutorials and guides: [docs.dispatch.run][docs].
-- Source: [stealthrocket/dispatch-py][github].
+- Source: [dispatchrun/dispatch-py][github].
 
 
 [docs]: https://docs.dispatch.run
-[github]: https://github.com/stealthrocket/dispatch-py
+[github]: https://github.com/dispatchrun/dispatch-py

--- a/examples/fanout/fanout.py
+++ b/examples/fanout/fanout.py
@@ -54,9 +54,9 @@ async def reduce_stargazers(repos):
 async def fanout():
     # Using gather, we fan-out the four following requests.
     repos = await gather(
-        get_repo("stealthrocket", "coroutine"),
-        get_repo("stealthrocket", "dispatch-py"),
-        get_repo("stealthrocket", "wzprof"),
+        get_repo("dispatchrun", "coroutine"),
+        get_repo("dispatchrun", "dispatch-py"),
+        get_repo("dispatchrun", "wzprof"),
     )
 
     stars = await reduce_stargazers(repos)

--- a/examples/github_stats/app.py
+++ b/examples/github_stats/app.py
@@ -51,7 +51,7 @@ async def get_contributors(repo_info: dict):
 
 @dispatch.function
 async def main():
-    repo_info = await get_repo_info("stealthrocket", "coroutine")
+    repo_info = await get_repo_info("dispatchrun", "coroutine")
     print(
         f"""Repository: {repo_info['full_name']}
 Stars: {repo_info['stargazers_count']}


### PR DESCRIPTION
This will address these failures in tests due to redirects not being handled by the http client https://github.com/dispatchrun/dispatch-py/actions/runs/8915493071/job/24485224353?pr=159