### PR TITLE
interoperability with asyncio (part 1)

### DIFF
--- a/src/dispatch/asyncio.py
+++ b/src/dispatch/asyncio.py
@@ -1,0 +1,105 @@
+import asyncio
+import functools
+import inspect
+import signal
+import threading
+
+class Runner:
+    """Runner is a class similar to asyncio.Runner but that we use for backward
+    compatibility with Python 3.10 and earlier.
+    """
+
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+        self._interrupt_count = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    def close(self):
+        try:
+            loop = self._loop
+            _cancel_all_tasks(loop)
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            if hasattr(loop, 'shutdown_default_executor'): # Python 3.9+
+                loop.run_until_complete(loop.shutdown_default_executor())
+        finally:
+            loop.close()
+
+    def get_loop(self):
+        return self._loop
+
+    def run(self, coro):
+        if not inspect.iscoroutine(coro):
+            raise ValueError("a coroutine was expected, got {!r}".format(coro))
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError("Runner.run() cannot be called from a running event loop")
+
+        task = self._loop.create_task(coro)
+        sigint_handler = None
+
+        if (threading.current_thread() is threading.main_thread()
+            and signal.getsignal(signal.SIGINT) is signal.default_int_handler
+        ):
+            sigint_handler = functools.partial(self._on_sigint, main_task=task)
+            try:
+                signal.signal(signal.SIGINT, sigint_handler)
+            except ValueError:
+                # `signal.signal` may throw if `threading.main_thread` does
+                # not support signals (e.g. embedded interpreter with signals
+                # not registered - see gh-91880)
+                sigint_handler = None
+
+        self._interrupt_count = 0
+        try:
+            asyncio.set_event_loop(self._loop)
+            return self._loop.run_until_complete(task)
+        except asyncio.CancelledError:
+            if self._interrupt_count > 0:
+                uncancel = getattr(task, "uncancel", None)
+                if uncancel is not None and uncancel() == 0:
+                    raise KeyboardInterrupt()
+            raise  # CancelledError
+        finally:
+            asyncio.set_event_loop(None)
+            if (sigint_handler is not None
+                and signal.getsignal(signal.SIGINT) is sigint_handler
+            ):
+                signal.signal(signal.SIGINT, signal.default_int_handler)
+
+    def _on_sigint(self, signum, frame, main_task):
+        self._interrupt_count += 1
+        if self._interrupt_count == 1 and not main_task.done():
+            main_task.cancel()
+            # wakeup loop if it is blocked by select() with long timeout
+            self._loop.call_soon_threadsafe(lambda: None)
+            return
+        raise KeyboardInterrupt()
+
+def _cancel_all_tasks(loop):
+    to_cancel = asyncio.all_tasks(loop)
+    if not to_cancel:
+        return
+
+    for task in to_cancel:
+        task.cancel()
+
+    loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler({
+                'message': 'unhandled exception during asyncio.run() shutdown',
+                'exception': task.exception(),
+                'task': task,
+            })

--- a/src/dispatch/asyncio.py
+++ b/src/dispatch/asyncio.py
@@ -4,6 +4,7 @@ import inspect
 import signal
 import threading
 
+
 class Runner:
     """Runner is a class similar to asyncio.Runner but that we use for backward
     compatibility with Python 3.10 and earlier.
@@ -24,7 +25,7 @@ class Runner:
             loop = self._loop
             _cancel_all_tasks(loop)
             loop.run_until_complete(loop.shutdown_asyncgens())
-            if hasattr(loop, 'shutdown_default_executor'): # Python 3.9+
+            if hasattr(loop, "shutdown_default_executor"):  # Python 3.9+
                 loop.run_until_complete(loop.shutdown_default_executor())
         finally:
             loop.close()
@@ -41,12 +42,15 @@ class Runner:
         except RuntimeError:
             pass
         else:
-            raise RuntimeError("Runner.run() cannot be called from a running event loop")
+            raise RuntimeError(
+                "Runner.run() cannot be called from a running event loop"
+            )
 
         task = self._loop.create_task(coro)
         sigint_handler = None
 
-        if (threading.current_thread() is threading.main_thread()
+        if (
+            threading.current_thread() is threading.main_thread()
             and signal.getsignal(signal.SIGINT) is signal.default_int_handler
         ):
             sigint_handler = functools.partial(self._on_sigint, main_task=task)
@@ -70,7 +74,8 @@ class Runner:
             raise  # CancelledError
         finally:
             asyncio.set_event_loop(None)
-            if (sigint_handler is not None
+            if (
+                sigint_handler is not None
                 and signal.getsignal(signal.SIGINT) is sigint_handler
             ):
                 signal.signal(signal.SIGINT, signal.default_int_handler)
@@ -83,6 +88,7 @@ class Runner:
             self._loop.call_soon_threadsafe(lambda: None)
             return
         raise KeyboardInterrupt()
+
 
 def _cancel_all_tasks(loop):
     to_cancel = asyncio.all_tasks(loop)
@@ -98,8 +104,10 @@ def _cancel_all_tasks(loop):
         if task.cancelled():
             continue
         if task.exception() is not None:
-            loop.call_exception_handler({
-                'message': 'unhandled exception during asyncio.run() shutdown',
-                'exception': task.exception(),
-                'task': task,
-            })
+            loop.call_exception_handler(
+                {
+                    "message": "unhandled exception during asyncio.run() shutdown",
+                    "exception": task.exception(),
+                    "task": task,
+                }
+            )

--- a/src/dispatch/experimental/lambda_handler.py
+++ b/src/dispatch/experimental/lambda_handler.py
@@ -18,6 +18,7 @@ Example:
         dispatch.handle(event, context, entrypoint="entrypoint")
     """
 
+import asyncio
 import base64
 import json
 import logging
@@ -92,7 +93,8 @@ class Dispatch(Registry):
 
         input = Input(req)
         try:
-            output = func._primitive_call(input)
+            with asyncio.Runner() as runner:
+                output = runner.run(func._primitive_call(input))
         except Exception:
             logger.error("function '%s' fatal error", req.function, exc_info=True)
             raise  # FIXME

--- a/src/dispatch/experimental/lambda_handler.py
+++ b/src/dispatch/experimental/lambda_handler.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 from awslambdaric.lambda_context import LambdaContext
 
+from dispatch.asyncio import Runner
 from dispatch.function import Registry
 from dispatch.proto import Input
 from dispatch.sdk.v1 import function_pb2 as function_pb
@@ -93,7 +94,7 @@ class Dispatch(Registry):
 
         input = Input(req)
         try:
-            with asyncio.Runner() as runner:
+            with Runner() as runner:
                 output = runner.run(func._primitive_call(input))
         except Exception:
             logger.error("function '%s' fatal error", req.function, exc_info=True)

--- a/src/dispatch/experimental/lambda_handler.py
+++ b/src/dispatch/experimental/lambda_handler.py
@@ -18,7 +18,6 @@ Example:
         dispatch.handle(event, context, entrypoint="entrypoint")
     """
 
-import asyncio
 import base64
 import json
 import logging

--- a/src/dispatch/fastapi.py
+++ b/src/dispatch/fastapi.py
@@ -102,11 +102,7 @@ def _new_app(function_registry: Registry, verification_key: Optional[Ed25519Publ
         # forcing execute() to be async.
         data: bytes = await request.body()
 
-        loop = asyncio.get_running_loop()
-
-        content = await loop.run_in_executor(
-            None,
-            function_service_run,
+        content = await function_service_run(
             str(request.url),
             request.method,
             request.headers,

--- a/src/dispatch/flask.py
+++ b/src/dispatch/flask.py
@@ -17,6 +17,7 @@ Example:
         my_function.dispatch()
     """
 
+import asyncio
 import logging
 from typing import Optional, Union
 
@@ -89,14 +90,17 @@ class Dispatch(Registry):
     def _execute(self):
         data: bytes = request.get_data(cache=False)
 
-        content = function_service_run(
-            request.url,
-            request.method,
-            dict(request.headers),
-            data,
-            self,
-            self._verification_key,
-        )
+        with asyncio.Runner() as runner:
+            content = runner.run(
+                function_service_run(
+                    request.url,
+                    request.method,
+                    dict(request.headers),
+                    data,
+                    self,
+                    self._verification_key,
+                ),
+            )
 
         res = make_response(content)
         res.content_type = "application/proto"

--- a/src/dispatch/flask.py
+++ b/src/dispatch/flask.py
@@ -23,6 +23,7 @@ from typing import Optional, Union
 
 from flask import Flask, make_response, request
 
+from dispatch.asyncio import Runner
 from dispatch.function import Registry
 from dispatch.http import FunctionServiceError, function_service_run
 from dispatch.signature import Ed25519PublicKey, parse_verification_key
@@ -90,7 +91,7 @@ class Dispatch(Registry):
     def _execute(self):
         data: bytes = request.get_data(cache=False)
 
-        with asyncio.Runner() as runner:
+        with Runner() as runner:
             content = runner.run(
                 function_service_run(
                     request.url,

--- a/src/dispatch/flask.py
+++ b/src/dispatch/flask.py
@@ -17,7 +17,6 @@ Example:
         my_function.dispatch()
     """
 
-import asyncio
 import logging
 from typing import Optional, Union
 

--- a/src/dispatch/http.py
+++ b/src/dispatch/http.py
@@ -9,6 +9,7 @@ from typing import Mapping, Optional, Union
 
 from http_message_signatures import InvalidSignature
 
+from dispatch.asyncio import Runner
 from dispatch.function import Registry
 from dispatch.proto import Input
 from dispatch.sdk.v1 import function_pb2 as function_pb
@@ -121,7 +122,7 @@ class FunctionService(BaseHTTPRequestHandler):
         url = self.requestline  # TODO: need full URL
 
         try:
-            with asyncio.Runner() as runner:
+            with Runner() as runner:
                 content = runner.run(
                     function_service_run(
                         url,

--- a/src/dispatch/http.py
+++ b/src/dispatch/http.py
@@ -1,6 +1,5 @@
 """Integration of Dispatch functions with http."""
 
-import asyncio
 import logging
 import os
 from datetime import timedelta

--- a/tests/dispatch/test_scheduler.py
+++ b/tests/dispatch/test_scheduler.py
@@ -1,7 +1,7 @@
-import asyncio
 import unittest
 from typing import Any, Callable, List, Optional, Set, Type
 
+from dispatch.asyncio import Runner
 from dispatch.coroutine import AnyException, any, call, gather, race
 from dispatch.experimental.durable import durable
 from dispatch.proto import Arguments, Call, CallResult, Error, Input, Output, TailCall
@@ -55,7 +55,7 @@ async def raises_error():
 
 class TestOneShotScheduler(unittest.TestCase):
     def setUp(self):
-        self.runner = asyncio.Runner()
+        self.runner = Runner()
 
     def tearDown(self):
         self.runner.close()

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -50,7 +50,7 @@ class TestFlask(unittest.TestCase):
         dispatch = create_dispatch_instance(app, endpoint="http://127.0.0.1:9999/")
 
         @dispatch.primitive_function
-        def my_function(input: Input) -> Output:
+        async def my_function(input: Input) -> Output:
             return Output.value(
                 f"You told me: '{input.input}' ({len(input.input)} characters)"
             )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -83,7 +83,7 @@ class TestHTTP(unittest.TestCase):
 
     def test_simple_request(self):
         @self.dispatch.registry.primitive_function
-        def my_function(input: Input) -> Output:
+        async def my_function(input: Input) -> Output:
             return Output.value(
                 f"You told me: '{input.input}' ({len(input.input)} characters)"
             )


### PR DESCRIPTION
This PR modifies the dispatch-py internals to build on the `asyncio` package in order to better integrate with frameworks like FastAPI, httpx, etc... and any other Python code that uses async/await constructs for I/O operations.

A couple of notable changes:

- The signature of primitive functions is changed to always be `async`, this is the only breaking change
- Due to interacting with the asyncio event loop, there are changes to the order of some operations. Notably, the depth-first traversal does not follow the same order anymore; this shouldn't have any impact on production applications since they wouldn't (shouldn't) rely on the order of async operations

In a few places, we are constructing temporary event loops (using a class similar to `asyncio.Runner`) to convert from blocking to asyncio code, for example in the http server we use in `dispatch.run()`. This a bit hacky and probably not optimal, we could do better by taking a dependency on `aiohttp`, I'll look into it in a follow up PR where I also want to investigate how we could integration the `.dispatch()` method with asyncio.

Fixes #122 