### PR TITLE
interoperability with asyncio (part 2): integration with aiohttp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 requires-python = ">= 3.8"
 dependencies = [
+    "aiohttp >= 3.9.4",
     "grpcio >= 1.60.0",
     "protobuf >= 4.24.0",
     "types-protobuf >= 4.24.0.20240129",

--- a/src/dispatch/aiohttp.py
+++ b/src/dispatch/aiohttp.py
@@ -1,0 +1,131 @@
+from typing import Optional, Union
+
+from aiohttp import web
+
+from dispatch.function import Registry
+from dispatch.http import (
+    FunctionServiceError,
+    function_service_run,
+    make_error_response_body,
+)
+from dispatch.signature import Ed25519PublicKey, parse_verification_key
+
+
+class Dispatch(web.Application):
+    """A Dispatch instance servicing as a http server."""
+
+    registry: Registry
+    verification_key: Optional[Ed25519PublicKey]
+
+    def __init__(
+        self,
+        registry: Registry,
+        verification_key: Optional[Union[Ed25519PublicKey, str, bytes]] = None,
+    ):
+        """Initialize a Dispatch application.
+
+        Args:
+            registry: The registry of functions to be serviced.
+
+            verification_key: The verification key to use for requests.
+        """
+        super().__init__()
+        self.registry = registry
+        self.verification_key = parse_verification_key(verification_key)
+        self.add_routes(
+            [
+                web.post(
+                    "/dispatch.sdk.v1.FunctionService/Run", self.handle_run_request
+                ),
+            ]
+        )
+
+    async def handle_run_request(self, request: web.Request) -> web.Response:
+        return await function_service_run_handler(
+            request, self.registry, self.verification_key
+        )
+
+
+class Server:
+    host: str
+    port: int
+    app: Dispatch
+
+    _runner: web.AppRunner
+    _site: web.TCPSite
+
+    def __init__(self, host: str, port: int, app: Dispatch):
+        self.host = host
+        self.port = port
+        self.app = app
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.stop()
+
+    async def start(self):
+        self._runner = web.AppRunner(self.app)
+        await self._runner.setup()
+
+        self._site = web.TCPSite(self._runner, self.host, self.port)
+        await self._site.start()
+
+    async def stop(self):
+        await self._site.stop()
+        await self._runner.cleanup()
+
+
+def make_error_response(status: int, code: str, message: str) -> web.Response:
+    body = make_error_response_body(code, message)
+    return web.Response(status=status, content_type="application/json", body=body)
+
+
+def make_error_response_invalid_argument(message: str) -> web.Response:
+    return make_error_response(400, "invalid_argument", message)
+
+
+def make_error_response_not_found(message: str) -> web.Response:
+    return make_error_response(404, "not_found", message)
+
+
+def make_error_response_unauthenticated(message: str) -> web.Response:
+    return make_error_response(401, "unauthenticated", message)
+
+
+def make_error_response_permission_denied(message: str) -> web.Response:
+    return make_error_response(403, "permission_denied", message)
+
+
+def make_error_response_internal(message: str) -> web.Response:
+    return make_error_response(500, "internal", message)
+
+
+async def function_service_run_handler(
+    request: web.Request,
+    function_registry: Registry,
+    verification_key: Optional[Ed25519PublicKey],
+) -> web.Response:
+    content_length = request.content_length
+    if content_length is None or content_length == 0:
+        return make_error_response_invalid_argument("content length is required")
+    if content_length < 0:
+        return make_error_response_invalid_argument("content length is negative")
+    if content_length > 16_000_000:
+        return make_error_response_invalid_argument("content length is too large")
+
+    data: bytes = await request.read()
+    try:
+        content = await function_service_run(
+            str(request.url),
+            request.method,
+            dict(request.headers),
+            data,
+            function_registry,
+            verification_key,
+        )
+    except FunctionServiceError as e:
+        return make_error_response(e.status, e.code, e.message)
+    return web.Response(status=200, content_type="application/proto", body=content)

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -15,10 +15,10 @@ import httpx
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 import dispatch.test.httpx
+from dispatch.aiohttp import Dispatch, Server
+from dispatch.asyncio import Runner
 from dispatch.experimental.durable.registry import clear_functions
 from dispatch.function import Arguments, Error, Function, Input, Output, Registry
-from dispatch.asyncio import Runner
-from dispatch.aiohttp import Dispatch, Server
 from dispatch.proto import _any_unpickle as any_unpickle
 from dispatch.sdk.v1 import call_pb2 as call_pb
 from dispatch.sdk.v1 import function_pb2 as function_pb
@@ -40,11 +40,12 @@ def run(runner: Runner, server: Server, ready: threading.Event):
         with runner:
             runner.run(serve(server, ready))
     except RuntimeError as e:
-        pass # silence errors triggered by stopping the loop after tests are done
+        pass  # silence errors triggered by stopping the loop after tests are done
+
 
 async def serve(server: Server, ready: threading.Event):
     async with server:
-        ready.set() # allow the test to continue after the server started
+        ready.set()  # allow the test to continue after the server started
         await asyncio.Event().wait()
 
 
@@ -67,7 +68,9 @@ class TestAIOHTTP(unittest.TestCase):
 
         self.client = httpx.Client(timeout=1.0)
         self.server = Server(host, port, self.dispatch)
-        self.thread = threading.Thread(target=lambda: run(self.runner, self.server, ready))
+        self.thread = threading.Thread(
+            target=lambda: run(self.runner, self.server, ready)
+        )
         self.thread.start()
         ready.wait()
 


### PR DESCRIPTION
Based on #122, this PR adds a new integration with the `aiohttp` framework, to enable dispatch applications that run on `aiohttp` servers, or use `aiohttp` clients to integrate with the `asyncio` facilities end-to-end.

This change is also a prerequisite to more modifications I want to bring to the SDK, that in my mind are other prerequisites for a sync mode where we can wait on dispatch calls in retrieve their results.

##  Thoughts on next steps

What I would like to get to is an API that matches `asyncio` more closely, for example:

```python
import dispatch

@dispatch.function
async def job():
    ...

dispatch.run(job())
```
This would cause a call to `job` to be dispatched to the scheduler, then waited on by the `dispatch.run` event loop, with the result returned.

This could also be composed with other `asyncio` operations:
```python
import dispatch

@dispatch.function
async def job():
    ...

async def main():
    # dispatch.sdk.v1.DispatchServer/Dispatch because not in the context
    # of a dispatch function, then poll for the result
    return await job() 

dispatch.run(main())
```

This would provide a unified model for both durable and volatile contexts, which would pave the road to simple testing constructs, examples, and integrations with RPC handlers etc...

For blocking world that doesn't use `asyncio`, the `.dispatch()` method can still be used, but we'd modify its return value to a form of future-like value where the result can be retrieved in a blocking fashion.

Let me know what you think!