### PR TITLE
Avoid pickling primitive values and proto messages

### DIFF
--- a/src/dispatch/any.py
+++ b/src/dispatch/any.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any
+
+import google.protobuf.any_pb2
+import google.protobuf.message
+import google.protobuf.wrappers_pb2
+from google.protobuf import descriptor_pool, message_factory
+
+from dispatch.sdk.python.v1 import pickled_pb2 as pickled_pb
+
+
+def marshal_any(value: Any) -> google.protobuf.any_pb2.Any:
+    any = google.protobuf.any_pb2.Any()
+    if isinstance(value, google.protobuf.message.Message):
+        any.Pack(value)
+    else:
+        p = pickled_pb.Pickled(pickled_value=pickle.dumps(value))
+        any.Pack(p, type_url_prefix="buf.build/stealthrocket/dispatch-proto/")
+    return any
+
+
+def unmarshal_any(any: google.protobuf.any_pb2.Any) -> Any:
+    if any.Is(pickled_pb.Pickled.DESCRIPTOR):
+        p = pickled_pb.Pickled()
+        any.Unpack(p)
+        return pickle.loads(p.pickled_value)
+
+    elif any.Is(google.protobuf.wrappers_pb2.BytesValue.DESCRIPTOR):
+        b = google.protobuf.wrappers_pb2.BytesValue()
+        any.Unpack(b)
+        try:
+            # Assume it's the legacy container for pickled values.
+            return pickle.loads(b.value)
+        except Exception as e:
+            # Otherwise, return the literal bytes.
+            return b.value
+
+    pool = descriptor_pool.Default()
+    msg_descriptor = pool.FindMessageTypeByName(any.TypeName())
+    proto = message_factory.GetMessageClass(msg_descriptor)()
+    any.Unpack(proto)
+    return proto

--- a/src/dispatch/any.py
+++ b/src/dispatch/any.py
@@ -12,12 +12,15 @@ from dispatch.sdk.python.v1 import pickled_pb2 as pickled_pb
 
 
 def marshal_any(value: Any) -> google.protobuf.any_pb2.Any:
+    if not isinstance(value, google.protobuf.message.Message):
+        value = pickled_pb.Pickled(pickled_value=pickle.dumps(value))
+
     any = google.protobuf.any_pb2.Any()
-    if isinstance(value, google.protobuf.message.Message):
-        any.Pack(value)
+    if value.DESCRIPTOR.full_name.startswith("dispatch.sdk."):
+        any.Pack(value, type_url_prefix="buf.build/stealthrocket/dispatch-proto/")
     else:
-        p = pickled_pb.Pickled(pickled_value=pickle.dumps(value))
-        any.Pack(p, type_url_prefix="buf.build/stealthrocket/dispatch-proto/")
+        any.Pack(value)
+
     return any
 
 

--- a/src/dispatch/any.py
+++ b/src/dispatch/any.py
@@ -4,14 +4,33 @@ import pickle
 from typing import Any
 
 import google.protobuf.any_pb2
+import google.protobuf.empty_pb2
 import google.protobuf.message
 import google.protobuf.wrappers_pb2
 from google.protobuf import descriptor_pool, message_factory
 
 from dispatch.sdk.python.v1 import pickled_pb2 as pickled_pb
 
+INT64_MIN = -9223372036854775808
+INT64_MAX = 9223372036854775807
+
 
 def marshal_any(value: Any) -> google.protobuf.any_pb2.Any:
+    if value is None:
+        value = google.protobuf.empty_pb2.Empty()
+    elif isinstance(value, bool):
+        value = google.protobuf.wrappers_pb2.BoolValue(value=value)
+    elif isinstance(value, int) and INT64_MIN <= value <= INT64_MAX:
+        # To keep things simple, serialize all integers as int64 on the wire.
+        # For larger integers, fall through and use pickle.
+        value = google.protobuf.wrappers_pb2.Int64Value(value=value)
+    elif isinstance(value, float):
+        value = google.protobuf.wrappers_pb2.DoubleValue(value=value)
+    elif isinstance(value, str):
+        value = google.protobuf.wrappers_pb2.StringValue(value=value)
+    elif isinstance(value, bytes):
+        value = google.protobuf.wrappers_pb2.BytesValue(value=value)
+
     if not isinstance(value, google.protobuf.message.Message):
         value = pickled_pb.Pickled(pickled_value=pickle.dumps(value))
 
@@ -25,23 +44,37 @@ def marshal_any(value: Any) -> google.protobuf.any_pb2.Any:
 
 
 def unmarshal_any(any: google.protobuf.any_pb2.Any) -> Any:
-    if any.Is(pickled_pb.Pickled.DESCRIPTOR):
-        p = pickled_pb.Pickled()
-        any.Unpack(p)
-        return pickle.loads(p.pickled_value)
-
-    elif any.Is(google.protobuf.wrappers_pb2.BytesValue.DESCRIPTOR):
-        b = google.protobuf.wrappers_pb2.BytesValue()
-        any.Unpack(b)
-        try:
-            # Assume it's the legacy container for pickled values.
-            return pickle.loads(b.value)
-        except Exception as e:
-            # Otherwise, return the literal bytes.
-            return b.value
-
     pool = descriptor_pool.Default()
     msg_descriptor = pool.FindMessageTypeByName(any.TypeName())
     proto = message_factory.GetMessageClass(msg_descriptor)()
     any.Unpack(proto)
+
+    if isinstance(proto, pickled_pb.Pickled):
+        return pickle.loads(proto.pickled_value)
+    elif isinstance(proto, google.protobuf.empty_pb2.Empty):
+        return None
+    elif isinstance(proto, google.protobuf.wrappers_pb2.BoolValue):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.Int32Value):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.Int64Value):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.UInt32Value):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.UInt64Value):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.FloatValue):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.DoubleValue):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.StringValue):
+        return proto.value
+    elif isinstance(proto, google.protobuf.wrappers_pb2.BytesValue):
+        try:
+            # Assume it's the legacy container for pickled values.
+            return pickle.loads(proto.value)
+        except Exception as e:
+            # Otherwise, return the literal bytes.
+            return proto.value
+
     return proto

--- a/src/dispatch/any.py
+++ b/src/dispatch/any.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pickle
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import google.protobuf.any_pb2
@@ -108,7 +108,7 @@ def unmarshal_any(any: google.protobuf.any_pb2.Any) -> Any:
             return proto.value
 
     elif isinstance(proto, google.protobuf.timestamp_pb2.Timestamp):
-        return proto.ToDatetime(tzinfo=UTC)
+        return proto.ToDatetime(tzinfo=timezone.utc)
 
     elif isinstance(proto, google.protobuf.duration_pb2.Duration):
         return proto.ToTimedelta()

--- a/src/dispatch/proto.py
+++ b/src/dispatch/proto.py
@@ -78,7 +78,7 @@ class Input:
 
         self._has_input = req.HasField("input")
         if self._has_input:
-            self._input = _pb_any_unpack(req.input)
+            self._input = _any_unpickle(req.input)
         else:
             if req.poll_result.coroutine_state:
                 raise IncompatibleStateError  # coroutine_state is deprecated
@@ -141,7 +141,7 @@ class Input:
         return Input(
             req=function_pb.RunRequest(
                 function=function,
-                input=_pb_any_pickle(input),
+                input=_any_pickle(input),
             )
         )
 
@@ -157,7 +157,7 @@ class Input:
             req=function_pb.RunRequest(
                 function=function,
                 poll_result=poll_pb.PollResult(
-                    typed_coroutine_state=_pb_any_pickle(coroutine_state),
+                    typed_coroutine_state=_any_pickle(coroutine_state),
                     results=[result._as_proto() for result in call_results],
                     error=error._as_proto() if error else None,
                 ),
@@ -241,7 +241,7 @@ class Output:
             else None
         )
         poll = poll_pb.Poll(
-            typed_coroutine_state=_pb_any_pickle(coroutine_state),
+            typed_coroutine_state=_any_pickle(coroutine_state),
             min_results=min_results,
             max_results=max_results,
             max_wait=max_wait,
@@ -279,7 +279,7 @@ class Call:
     correlation_id: Optional[int] = None
 
     def _as_proto(self) -> call_pb.Call:
-        input_bytes = _pb_any_pickle(self.input)
+        input_bytes = _any_pickle(self.input)
         return call_pb.Call(
             correlation_id=self.correlation_id,
             endpoint=self.endpoint,
@@ -301,7 +301,7 @@ class CallResult:
         output_any = None
         error_proto = None
         if self.output is not None:
-            output_any = _pb_any_pickle(self.output)
+            output_any = _any_pickle(self.output)
         if self.error is not None:
             error_proto = self.error._as_proto()
 
@@ -440,31 +440,17 @@ class Error:
         )
 
 
-def _any_unpickle(any: google.protobuf.any_pb2.Any) -> Any:
-    if any.Is(pickled_pb.Pickled.DESCRIPTOR):
-        p = pickled_pb.Pickled()
-        any.Unpack(p)
-        return pickle.loads(p.pickled_value)
-
-    elif any.Is(google.protobuf.wrappers_pb2.BytesValue.DESCRIPTOR):  # legacy container
-        b = google.protobuf.wrappers_pb2.BytesValue()
-        any.Unpack(b)
-        return pickle.loads(b.value)
-
-    elif not any.type_url and not any.value:
-        return None
-
-    raise InvalidArgumentError(f"unsupported pickled value container: {any.type_url}")
-
-
-def _pb_any_pickle(value: Any) -> google.protobuf.any_pb2.Any:
-    p = pickled_pb.Pickled(pickled_value=pickle.dumps(value))
+def _any_pickle(value: Any) -> google.protobuf.any_pb2.Any:
     any = google.protobuf.any_pb2.Any()
-    any.Pack(p, type_url_prefix="buf.build/stealthrocket/dispatch-proto/")
+    if isinstance(value, google.protobuf.message.Message):
+        any.Pack(value)
+    else:
+        p = pickled_pb.Pickled(pickled_value=pickle.dumps(value))
+        any.Pack(p, type_url_prefix="buf.build/stealthrocket/dispatch-proto/")
     return any
 
 
-def _pb_any_unpack(any: google.protobuf.any_pb2.Any) -> Any:
+def _any_unpickle(any: google.protobuf.any_pb2.Any) -> Any:
     if any.Is(pickled_pb.Pickled.DESCRIPTOR):
         p = pickled_pb.Pickled()
         any.Unpack(p)

--- a/tests/dispatch/test_any.py
+++ b/tests/dispatch/test_any.py
@@ -1,5 +1,5 @@
 import pickle
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from dispatch.any import INT64_MAX, INT64_MIN, marshal_any, unmarshal_any
 from dispatch.sdk.v1 import error_pb2 as error_pb
@@ -70,16 +70,16 @@ def test_unmarshal_bytes():
 
 
 def test_unmarshal_timestamp():
-    ts = datetime.fromtimestamp(
-        1719372909.641448
-    )  # datetime.datetime(2024, 6, 26, 13, 35, 9, 641448)
+    ts = datetime.fromtimestamp(1719372909.641448, UTC)
     boxed = marshal_any(ts)
+    assert "type.googleapis.com/google.protobuf.Timestamp" == boxed.type_url
     assert ts == unmarshal_any(boxed)
 
 
 def test_unmarshal_duration():
     d = timedelta(seconds=1, microseconds=1234)
     boxed = marshal_any(d)
+    assert "type.googleapis.com/google.protobuf.Duration" == boxed.type_url
     assert d == unmarshal_any(boxed)
 
 

--- a/tests/dispatch/test_any.py
+++ b/tests/dispatch/test_any.py
@@ -1,40 +1,71 @@
 import pickle
 from datetime import datetime, timedelta
 
-from dispatch.any import marshal_any, unmarshal_any
+from dispatch.any import INT64_MAX, INT64_MIN, marshal_any, unmarshal_any
 from dispatch.sdk.v1 import error_pb2 as error_pb
 
 
 def test_unmarshal_none():
     boxed = marshal_any(None)
+    assert "type.googleapis.com/google.protobuf.Empty" == boxed.type_url
     assert None == unmarshal_any(boxed)
 
 
 def test_unmarshal_bool():
     boxed = marshal_any(True)
+    assert "type.googleapis.com/google.protobuf.BoolValue" == boxed.type_url
     assert True == unmarshal_any(boxed)
 
 
 def test_unmarshal_integer():
     boxed = marshal_any(1234)
+    assert "type.googleapis.com/google.protobuf.Int64Value" == boxed.type_url
     assert 1234 == unmarshal_any(boxed)
 
     boxed = marshal_any(-1234)
+    assert "type.googleapis.com/google.protobuf.Int64Value" == boxed.type_url
     assert -1234 == unmarshal_any(boxed)
+
+
+def test_unmarshal_int64_limits():
+    boxed = marshal_any(INT64_MIN)
+    assert "type.googleapis.com/google.protobuf.Int64Value" == boxed.type_url
+    assert INT64_MIN == unmarshal_any(boxed)
+
+    boxed = marshal_any(INT64_MAX)
+    assert "type.googleapis.com/google.protobuf.Int64Value" == boxed.type_url
+    assert INT64_MAX == unmarshal_any(boxed)
+
+    boxed = marshal_any(INT64_MIN - 1)
+    assert (
+        "buf.build/stealthrocket/dispatch-proto/dispatch.sdk.python.v1.Pickled"
+        == boxed.type_url
+    )
+    assert INT64_MIN - 1 == unmarshal_any(boxed)
+
+    boxed = marshal_any(INT64_MAX + 1)
+    assert (
+        "buf.build/stealthrocket/dispatch-proto/dispatch.sdk.python.v1.Pickled"
+        == boxed.type_url
+    )
+    assert INT64_MAX + 1 == unmarshal_any(boxed)
 
 
 def test_unmarshal_float():
     boxed = marshal_any(3.14)
+    assert "type.googleapis.com/google.protobuf.DoubleValue" == boxed.type_url
     assert 3.14 == unmarshal_any(boxed)
 
 
 def test_unmarshal_string():
     boxed = marshal_any("foo")
+    assert "type.googleapis.com/google.protobuf.StringValue" == boxed.type_url
     assert "foo" == unmarshal_any(boxed)
 
 
 def test_unmarshal_bytes():
     boxed = marshal_any(b"bar")
+    assert "type.googleapis.com/google.protobuf.BytesValue" == boxed.type_url
     assert b"bar" == unmarshal_any(boxed)
 
 

--- a/tests/dispatch/test_any.py
+++ b/tests/dispatch/test_any.py
@@ -94,3 +94,18 @@ def test_unmarshal_protobuf_message():
     )
 
     assert message == unmarshal_any(boxed)
+
+
+def test_unmarshal_json_like():
+    value = {
+        "null": None,
+        "bool": True,
+        "int": 11,
+        "float": 3.14,
+        "string": "foo",
+        "list": [None, "abc", 1.23],
+        "object": {"a": ["b", "c"]},
+    }
+    boxed = marshal_any(value)
+    assert "type.googleapis.com/google.protobuf.Value" == boxed.type_url
+    assert value == unmarshal_any(boxed)

--- a/tests/dispatch/test_any.py
+++ b/tests/dispatch/test_any.py
@@ -1,5 +1,5 @@
 import pickle
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from dispatch.any import INT64_MAX, INT64_MIN, marshal_any, unmarshal_any
 from dispatch.sdk.v1 import error_pb2 as error_pb
@@ -70,7 +70,7 @@ def test_unmarshal_bytes():
 
 
 def test_unmarshal_timestamp():
-    ts = datetime.fromtimestamp(1719372909.641448, UTC)
+    ts = datetime.fromtimestamp(1719372909.641448, timezone.utc)
     boxed = marshal_any(ts)
     assert "type.googleapis.com/google.protobuf.Timestamp" == boxed.type_url
     assert ts == unmarshal_any(boxed)

--- a/tests/dispatch/test_any.py
+++ b/tests/dispatch/test_any.py
@@ -1,0 +1,65 @@
+import pickle
+from datetime import datetime, timedelta
+
+from dispatch.any import marshal_any, unmarshal_any
+from dispatch.sdk.v1 import error_pb2 as error_pb
+
+
+def test_unmarshal_none():
+    boxed = marshal_any(None)
+    assert None == unmarshal_any(boxed)
+
+
+def test_unmarshal_bool():
+    boxed = marshal_any(True)
+    assert True == unmarshal_any(boxed)
+
+
+def test_unmarshal_integer():
+    boxed = marshal_any(1234)
+    assert 1234 == unmarshal_any(boxed)
+
+    boxed = marshal_any(-1234)
+    assert -1234 == unmarshal_any(boxed)
+
+
+def test_unmarshal_float():
+    boxed = marshal_any(3.14)
+    assert 3.14 == unmarshal_any(boxed)
+
+
+def test_unmarshal_string():
+    boxed = marshal_any("foo")
+    assert "foo" == unmarshal_any(boxed)
+
+
+def test_unmarshal_bytes():
+    boxed = marshal_any(b"bar")
+    assert b"bar" == unmarshal_any(boxed)
+
+
+def test_unmarshal_timestamp():
+    ts = datetime.fromtimestamp(
+        1719372909.641448
+    )  # datetime.datetime(2024, 6, 26, 13, 35, 9, 641448)
+    boxed = marshal_any(ts)
+    assert ts == unmarshal_any(boxed)
+
+
+def test_unmarshal_duration():
+    d = timedelta(seconds=1, microseconds=1234)
+    boxed = marshal_any(d)
+    assert d == unmarshal_any(boxed)
+
+
+def test_unmarshal_protobuf_message():
+    message = error_pb.Error(type="internal", message="oops")
+    boxed = marshal_any(message)
+
+    # Check the message isn't pickled (in which case the type_url would
+    # end with dispatch.sdk.python.v1.Pickled).
+    assert (
+        "buf.build/stealthrocket/dispatch-proto/dispatch.sdk.v1.Error" == boxed.type_url
+    )
+
+    assert message == unmarshal_any(boxed)

--- a/tests/dispatch/test_scheduler.py
+++ b/tests/dispatch/test_scheduler.py
@@ -3,10 +3,10 @@ from typing import Any, Callable, List, Optional, Set, Type
 
 import pytest
 
+from dispatch.any import unmarshal_any
 from dispatch.coroutine import AnyException, any, call, gather, race
 from dispatch.experimental.durable import durable
 from dispatch.proto import Arguments, Call, CallResult, Error, Input, Output, TailCall
-from dispatch.proto import _any_unpickle as any_unpickle
 from dispatch.scheduler import (
     AllFuture,
     AnyFuture,
@@ -464,7 +464,7 @@ async def resume(
     poll = assert_poll(prev_output)
     input = Input.from_poll_results(
         main.__qualname__,
-        any_unpickle(poll.typed_coroutine_state),
+        unmarshal_any(poll.typed_coroutine_state),
         call_results,
         Error.from_exception(poll_error) if poll_error else None,
     )
@@ -489,7 +489,7 @@ def assert_exit_result_value(output: Output, expect: Any):
     result = assert_exit_result(output)
     assert result.HasField("output")
     assert not result.HasField("error")
-    assert expect == any_unpickle(result.output)
+    assert expect == unmarshal_any(result.output)
 
 
 def assert_exit_result_error(

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -19,7 +19,6 @@ from dispatch.asyncio import Runner
 from dispatch.experimental.durable.registry import clear_functions
 from dispatch.fastapi import Dispatch
 from dispatch.function import Arguments, Client, Error, Input, Output, Registry
-from dispatch.proto import _any_unpickle as any_unpickle
 from dispatch.sdk.v1 import call_pb2 as call_pb
 from dispatch.sdk.v1 import function_pb2 as function_pb
 from dispatch.signature import (


### PR DESCRIPTION
This PR updates the SDK to avoid using pickle to serialize inputs and outputs unless necessary.

If an input or output value is a protobuf message, it's now serialized directly.

If an input or output value is primitive (null, boolean, integer, float, string, bytes, timestamp, duration), we serialize it using one of the built-in protobuf wrappers.

If an input or output value is a JSON-like list or dict, we serialize it using the built-in structpb wrappers.